### PR TITLE
TOTP via PyOTP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM certbot/certbot
 
 COPY . src/certbot-dns-schlundtech
 
+RUN pip install pyotp
 RUN pip install --no-cache-dir --editable src/certbot-dns-schlundtech

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,4 @@ FROM certbot/certbot
 
 COPY . src/certbot-dns-schlundtech
 
-RUN pip install pyotp
 RUN pip install --no-cache-dir --editable src/certbot-dns-schlundtech

--- a/certbot_dns_schlundtech/dns_schlundtech.py
+++ b/certbot_dns_schlundtech/dns_schlundtech.py
@@ -1,6 +1,7 @@
 """DNS Authenticator for the SchlundTech XML Gateway."""
 import logging
 import xml.etree.ElementTree as Et
+import pyotp
 try:
     from urllib.request import Request, urlopen
     from urllib.error import HTTPError, URLError
@@ -87,7 +88,8 @@ class _SchlundtechGatewayClient:
             'context': self.context,
         }
         if self.token is not None:
-            result['token'] = self.token
+            totp = pyotp.TOTP(self.token)
+            result['token'] = totp.now()
         return result
 
     def _call(self, task):

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requires = [
     'mock',
     'setuptools',
     'zope.interface',
+    'pyotp',
 ]
 
 docs_extras = [


### PR DESCRIPTION
Hi,

I did some changes for 2FA. Now it's using PyOTP to generate the access token. I tested it with my Schlundtech account via the Docker version. I also edited the setup.py install_requiremnts, but I didn't test it his way. Is there a better way for Docker than RUN pip install for PyOTP?
This is my first (and probably last) Python program, so I didn't change the parameter name for TOKEN, as I didn't wont to break anything. Maybe the name is not the best anymore.

I tested it a few times with my account and also with more than one domain via the -d option. (domain1.com, *.domain1.com, domain2.com, *.domain2.com).

Let me know, if you need some further testing or some changes.

Best regards from Ruhrpott
Stefan